### PR TITLE
refactor: use promises graph instead of iterating all remaining actio…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-graph-resolver",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": {
     "name": "Sela Marjan Almog & Maksym Petruk",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,14 @@
-export const DuplicateNodeIdError = node =>
-  new Error(`Async node with id: '${node.id}' alredy exists`);
+export const DuplicateNodeIdError = nodeId =>
+  new Error(`Async node with id: '${nodeId}' alredy exists`);
 
-export const CircularDependencyError = node =>
+export const CircularDependencyError = (circularPath: string[]) =>
   new Error(
-    `Adding async node with id: '${node.id}' creates circular dependency`,
+    `A circular dependency path was detected: ${circularPath.join(' -> ')}`,
   );
 
-export const InvalidDependencyError = dependencyId =>
-  new Error(`Dependency with id: '${dependencyId}' doesn't exist`);
+export const InvalidDependenciesError = dependencyIds =>
+  new Error(
+    `Dependency with id(s): [${dependencyIds.map(
+      id => `'${id}'`,
+    )}] do not exist`,
+  );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import {
   DuplicateNodeIdError,
+  InvalidDependenciesError,
   CircularDependencyError,
-  InvalidDependencyError,
 } from './errors';
 
 export interface IAsyncNode {
@@ -10,131 +10,139 @@ export interface IAsyncNode {
   dependencies?: string[];
 }
 
-const hasCircularDependencies = (nodes: IAsyncNode[], node: IAsyncNode) => {
-  const flattenedDependencies = new Set();
-
-  const internalSearch = ({ id, dependencies }: IAsyncNode) => {
-    if (flattenedDependencies.has(id)) {
-      return true;
-    }
-    flattenedDependencies.add(id);
-    const hasCircularDepndency = dependencies.some(_id => {
-      const dependecyNode = nodes.find(_node => _node.id === _id);
-      if (!dependecyNode) {
-        return false;
-      }
-      return internalSearch(dependecyNode);
-    });
-    if (!hasCircularDepndency) {
-      flattenedDependencies.delete(id);
-    }
-    return hasCircularDepndency;
-  };
-
-  return internalSearch(node);
-};
+interface INodeData {
+  nodeDependencyPromises: Promise<any>;
+  nodePromise: Promise<any>;
+}
 
 export class AsyncGraph {
-  private readonly nodes: IAsyncNode[];
-  private unresolvedNodes: IAsyncNode[];
-  private result: any;
-  private hasFailedNodes: boolean;
-  private resolveGraph: (error?: Error) => void;
-  private graphPromise: Promise<any>;
+  private readonly nodePromises: Map<string, INodeData> | {} = {};
+  private readonly dependenciesGraph: Map<string, string[]> | {} = {};
+  private resolveRootPromise: () => void;
+  private readonly rootPromise: Promise<any> = new Promise(resolve => {
+    this.resolveRootPromise = resolve;
+  });
+  private readonly result: any = {};
+  private isGraphExecutionAborted: boolean = false;
+
+  private addToDependenciesGraph(dependency, dependant) {
+    if (this.dependenciesGraph.hasOwnProperty(dependency)) {
+      this.dependenciesGraph[dependency].push(dependant);
+    } else {
+      this.dependenciesGraph[dependency] = [dependant];
+    }
+  }
+
+  private abortGraphExecution(reason) {
+    this.isGraphExecutionAborted = true;
+    throw reason;
+  }
+
+  private getNodePromise(id: string, run: (object?: any) => Promise<any>) {
+    return this.rootPromise
+      .then(() => Promise.all(this.nodePromises[id].nodeDependencyPromises))
+      .then(() => {
+        if (!this.isGraphExecutionAborted) {
+          return run(this.result).then(nodeResult => {
+            this.result[id] = nodeResult;
+          });
+        }
+      })
+      .catch(reason => this.abortGraphExecution(reason));
+  }
+
+  private buildPromisesGraph() {
+    Object.keys(this.dependenciesGraph).forEach(dependencyId => {
+      const dependencyPromise = this.nodePromises[dependencyId].nodePromise;
+      const dependantIds: string[] = this.dependenciesGraph[dependencyId];
+      dependantIds.forEach(dependantId =>
+        this.nodePromises[dependantId].nodeDependencyPromises.push(
+          dependencyPromise,
+        ),
+      );
+    });
+  }
+
+  private getGraphPromise() {
+    const nodesPromises: Promise<any>[] = Object.keys(this.nodePromises).map(
+      nodeId => this.nodePromises[nodeId].nodePromise,
+    );
+
+    return Promise.all(nodesPromises).then(() => {
+      return this.result;
+    });
+  }
+
+  private addNodePromise(id, run) {
+    this.nodePromises[id] = {
+      nodeDependencyPromises: [],
+      nodePromise: this.getNodePromise(id, run),
+    };
+  }
+
+  private mapNodeIdToDependencyIds(id, dependencies) {
+    dependencies.forEach(dependencyId =>
+      this.addToDependenciesGraph(dependencyId, id),
+    );
+  }
+
+  private validateUniqueNodeId(id) {
+    if (Object.keys(this.nodePromises).includes(id)) {
+      throw DuplicateNodeIdError(id);
+    }
+  }
+
+  private validateAllDependenciesExists() {
+    const allNodeIds = Object.keys(this.nodePromises);
+    const allDependeciesIds = Object.keys(this.dependenciesGraph);
+    const nonExistingDependencies = allDependeciesIds.filter(
+      dependencyId => !allNodeIds.includes(dependencyId),
+    );
+    if (nonExistingDependencies.length > 0) {
+      throw InvalidDependenciesError(nonExistingDependencies);
+    }
+  }
+
+  private validateDependencyIsntInACircle(dependencyId, path: string[]) {
+    if (path.includes(dependencyId)) {
+      const circularPath = path.slice(path.indexOf(dependencyId));
+      throw CircularDependencyError([...circularPath, dependencyId]);
+    }
+    if (this.dependenciesGraph[dependencyId]) {
+      this.dependenciesGraph[dependencyId].forEach(depedantId =>
+        this.validateDependencyIsntInACircle(depedantId, [
+          ...path,
+          dependencyId,
+        ]),
+      );
+    }
+  }
+
+  private validateNoCircularDependencies() {
+    Object.keys(this.dependenciesGraph).forEach(dependencyId =>
+      this.validateDependencyIsntInACircle(dependencyId, []),
+    );
+  }
 
   constructor() {
-    this.nodes = [];
     this.resolve = this.resolve.bind(this);
     this.addNode = this.addNode.bind(this);
   }
 
-  private validateNode(unverifiedNode: IAsyncNode) {
-    const hasUniqueId = !this.nodes.some(node => node.id === unverifiedNode.id);
-    if (!hasUniqueId) {
-      throw DuplicateNodeIdError(unverifiedNode);
-    }
-
-    const hasCircularDependency = hasCircularDependencies(
-      this.nodes.concat(unverifiedNode),
-      unverifiedNode,
-    );
-    if (hasCircularDependency) {
-      throw CircularDependencyError(unverifiedNode);
-    }
-  }
-
   public addNode({ id, run, dependencies = [] }: IAsyncNode) {
-    const asyncNode = { id, run, dependencies };
-    this.validateNode(asyncNode);
-    this.nodes.push(asyncNode);
+    this.validateUniqueNodeId(id);
+    this.addNodePromise(id, run);
+    this.mapNodeIdToDependencyIds(id, dependencies);
     return this;
   }
 
-  private verifyGraphDependencies() {
-    const ids = new Set(this.nodes.map(({ id }) => id));
-    const dependenciesIds = new Set(
-      this.nodes.reduce(
-        (dependenciesList, node) => dependenciesList.concat(node.dependencies),
-        [],
-      ),
-    );
-    dependenciesIds.forEach(dependencyId => {
-      if (!ids.has(dependencyId)) {
-        throw InvalidDependencyError(dependencyId);
-      }
-    });
-  }
-
   public resolve() {
-    if (!this.graphPromise) {
-      this.unresolvedNodes = [...this.nodes];
-      this.result = {};
+    this.validateAllDependenciesExists();
+    this.validateNoCircularDependencies();
 
-      this.verifyGraphDependencies();
+    this.buildPromisesGraph();
+    this.resolveRootPromise();
 
-      this.resolveReadyNodes();
-
-      this.graphPromise = new Promise((resolve, reject) => {
-        this.resolveGraph = error =>
-          error ? reject(error) : resolve(this.result);
-      });
-    }
-
-    return this.graphPromise;
-  }
-
-  private isReadyToResolve(node: IAsyncNode) {
-    return node.dependencies.every(dep => this.result.hasOwnProperty(dep));
-  }
-
-  private resolveSingleNode(node: IAsyncNode) {
-    return node.run(this.result).then(nodeResult => {
-      this.result = {
-        ...this.result,
-        ...{ [node.id]: nodeResult },
-      };
-      this.resolveReadyNodes();
-    });
-  }
-
-  private resolveReadyNodes() {
-    if (
-      this.nodes.length === Object.keys(this.result).length ||
-      this.hasFailedNodes
-    ) {
-      return this.resolveGraph();
-    }
-    this.unresolvedNodes
-      .filter(node => this.isReadyToResolve(node))
-      .forEach(node =>
-        this.resolveSingleNode(node).catch(error => {
-          this.hasFailedNodes = true;
-          this.resolveGraph(error);
-        }),
-      );
-
-    this.unresolvedNodes = this.unresolvedNodes.filter(
-      node => !this.isReadyToResolve(node),
-    );
+    return this.getGraphPromise();
   }
 }

--- a/test/basic-functionality.spec.ts
+++ b/test/basic-functionality.spec.ts
@@ -1,7 +1,7 @@
 import { AsyncGraph } from '../src';
 import { expect } from 'chai';
 
-describe('default formatter', () => {
+describe('basic functionality', () => {
   it('should resolve single node', async () => {
     const graph = new AsyncGraph();
 


### PR DESCRIPTION
…n for every action resolve, and moving circular dependencies validation into the resolve method